### PR TITLE
speakeasy: Add Studio AI schema to input list

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -4,6 +4,7 @@ sources:
     livepeer-studio-api:
         inputs:
             - location: https://raw.githubusercontent.com/livepeer/studio/master/packages/api/src/schema/api-schema.yaml
+            - location: https://raw.githubusercontent.com/livepeer/studio/master/packages/api/src/schema/ai-api-schema.yaml
         registry:
             location: registry.speakeasyapi.dev/livepeer/livepeer-studio/livepeer-studio-api
 targets:


### PR DESCRIPTION
I know this is not maintained anymore but let's keep it consistent with the others.